### PR TITLE
Potential fix for code scanning alert no. 72: Deserialization of user-controlled data

### DIFF
--- a/modules/training.py
+++ b/modules/training.py
@@ -237,12 +237,30 @@ def change_rank_limit(use_higher_ranks: bool):
 
 
 def clean_path(base_path: str, path: str):
-    """Strips unusual symbols and forcibly builds a path as relative to the intended directory."""
-    path = path.replace('\\', '/').replace('..', '_')
-    if base_path is None:
-        return path
+    """Strips unusual symbols and builds a path that is safely constrained to the intended directory."""
+    # Normalize separators and remove obvious traversal tokens
+    if path is None:
+        path = ""
+    path = path.replace("\\", "/").strip()
+    # Disallow absolute paths from untrusted input
+    if os.path.isabs(path):
+        raise ValueError("Absolute paths are not allowed.")
+    path = path.replace("..", "_")
 
-    return f'{Path(base_path).absolute()}/{path}'
+    # If no base path is provided, return a relative, normalized path
+    if base_path is None:
+        # Ensure we don't accidentally create an absolute path here
+        return str(Path(path))
+
+    # Resolve the base directory and candidate path, then ensure containment
+    base = Path(base_path).resolve()
+    candidate = (base / path).resolve()
+
+    # Ensure the candidate is the base itself or a descendant of it
+    if candidate != base and base not in candidate.parents:
+        raise ValueError("Path escapes the allowed base directory.")
+
+    return str(candidate)
 
 
 def backup_adapter(input_folder):
@@ -303,16 +321,14 @@ def do_train(lora_name: str, always_override: bool, q_proj_en: bool, v_proj_en: 
 
     # == Input validation / processing ==
     yield "Preparing the input..."
-    lora_file_path = clean_path(shared.args.lora_dir, lora_name)
-    if lora_file_path.strip() == '':
-        yield "Missing or invalid LoRA file name input."
+    try:
+        lora_file_path = clean_path(shared.args.lora_dir, lora_name)
+    except ValueError:
+        yield "Invalid LoRA file path."
         return
 
-    # Normalize and ensure the path stays within the LoRA directory
-    lora_file_path = str(Path(lora_file_path).resolve())
-    base_lora_dir = str(Path(shared.args.lora_dir).resolve())
-    if not lora_file_path.startswith(base_lora_dir + os.sep):
-        yield "Invalid LoRA file path."
+    if not lora_file_path or lora_file_path.strip() == "":
+        yield "Missing or invalid LoRA file name input."
         return
 
     actual_lr = float(learning_rate)

--- a/modules/training.py
+++ b/modules/training.py
@@ -237,27 +237,31 @@ def change_rank_limit(use_higher_ranks: bool):
 
 
 def clean_path(base_path: str, path: str):
-    """Strips unusual symbols and builds a path that is safely constrained to the intended directory."""
-    # Normalize separators and remove obvious traversal tokens
+    """Build a safe path from untrusted input, constrained to an allowed base when provided."""
     if path is None:
         path = ""
-    path = path.replace("\\", "/").strip()
-    # Disallow absolute paths from untrusted input
-    if os.path.isabs(path):
+
+    user_path = Path(path.strip())
+
+    # Only allow relative user input.
+    if user_path.is_absolute():
         raise ValueError("Absolute paths are not allowed.")
-    path = path.replace("..", "_")
 
-    # If no base path is provided, return a relative, normalized path
+    # Reject traversal segments explicitly.
+    if ".." in user_path.parts:
+        raise ValueError("Path traversal is not allowed.")
+
+    # If no base is provided, return normalized relative path.
     if base_path is None:
-        # Ensure we don't accidentally create an absolute path here
-        return str(Path(path))
+        return str(user_path)
 
-    # Resolve the base directory and candidate path, then ensure containment
     base = Path(base_path).resolve()
-    candidate = (base / path).resolve()
+    candidate = (base / user_path).resolve()
 
-    # Ensure the candidate is the base itself or a descendant of it
-    if candidate != base and base not in candidate.parents:
+    # Enforce that candidate stays inside base.
+    try:
+        candidate.relative_to(base)
+    except ValueError:
         raise ValueError("Path escapes the allowed base directory.")
 
     return str(candidate)

--- a/modules/training.py
+++ b/modules/training.py
@@ -241,22 +241,26 @@ def clean_path(base_path: str, path: str):
     if path is None:
         path = ""
 
-    user_path = Path(path.strip())
+    normalized_input = path.strip().replace("\\", "/")
+    user_path = Path(normalized_input)
 
     # Only allow relative user input.
     if user_path.is_absolute():
         raise ValueError("Absolute paths are not allowed.")
 
-    # Reject traversal segments explicitly.
-    if ".." in user_path.parts:
+    # Reject empty/current-dir/traversal segments explicitly.
+    if any(part in ("", ".", "..") for part in user_path.parts):
         raise ValueError("Path traversal is not allowed.")
+
+    # Build a normalized safe relative path from validated parts.
+    safe_relative = Path(*user_path.parts)
 
     # If no base is provided, return normalized relative path.
     if base_path is None:
-        return str(user_path)
+        return str(safe_relative)
 
     base = Path(base_path).resolve()
-    candidate = (base / user_path).resolve()
+    candidate = (base / safe_relative).resolve()
 
     # Enforce that candidate stays inside base.
     try:

--- a/modules/training.py
+++ b/modules/training.py
@@ -303,12 +303,18 @@ def do_train(lora_name: str, always_override: bool, q_proj_en: bool, v_proj_en: 
 
     # == Input validation / processing ==
     yield "Preparing the input..."
-    lora_file_path = clean_path(None, lora_name)
+    lora_file_path = clean_path(shared.args.lora_dir, lora_name)
     if lora_file_path.strip() == '':
         yield "Missing or invalid LoRA file name input."
         return
 
-    lora_file_path = f"{Path(shared.args.lora_dir)}/{lora_file_path}"
+    # Normalize and ensure the path stays within the LoRA directory
+    lora_file_path = str(Path(lora_file_path).resolve())
+    base_lora_dir = str(Path(shared.args.lora_dir).resolve())
+    if not lora_file_path.startswith(base_lora_dir + os.sep):
+        yield "Invalid LoRA file path."
+        return
+
     actual_lr = float(learning_rate)
     model_type = type(shared.model).__name__
 


### PR DESCRIPTION
Potential fix for [https://github.com/unixwzrd/text-generation-webui-macos/security/code-scanning/72](https://github.com/unixwzrd/text-generation-webui-macos/security/code-scanning/72)

General approach: Avoid using general-purpose pickle-based deserialization (here via `torch.load`) on data whose location is influenced by user input. If you must load only tensors saved with `torch.save`, use the `weights_only=True` option together with `torch.load`’s `mmap`-like restrictions, or even better, use `torch.load` through a restricted `pickle_module` such as `safetensors` or enforce strong path validation and limit to a known safe directory. Since we already pass `weights_only=True`, the main remaining problem is that `lora_file_path` can point to arbitrary locations, potentially outside the intended LoRA directory.

Best fix for this code with minimal behavior change:

1. **Constrain the path to the intended LoRA directory** by always passing a `base_path` into `clean_path`, instead of `None`. This ensures the resolved path is rooted under `shared.args.lora_dir` and prevents users from escaping it with path tricks.
2. **Harden the path further** by normalizing it and checking that the final `lora_file_path` is still inside `shared.args.lora_dir` before using it with `torch.load`. This defends against subtle edge cases and any future changes to `clean_path`.
3. Leave the actual call to `torch.load(..., weights_only=True)` unchanged, as this is the expected way to load adapter weights and switching format (e.g., to JSON) would break functionality.

Concretely:

- Near the top of `do_train`, change:

  ```python
  lora_file_path = clean_path(None, lora_name)
  ...
  lora_file_path = f"{Path(shared.args.lora_dir)}/{lora_file_path}"
  ```

  to use `shared.args.lora_dir` as the `base_path`:

  ```python
  lora_file_path = clean_path(shared.args.lora_dir, lora_name)
  ```

- After computing `lora_file_path`, add a normalization and safety check:

  ```python
  lora_file_path = str(Path(lora_file_path).resolve())
  base_lora_dir = str(Path(shared.args.lora_dir).resolve())
  if not lora_file_path.startswith(base_lora_dir + os.sep):
      yield "Invalid LoRA file path."
      return
  ```

  This ensures that even if `clean_path` is modified later, paths still cannot escape `shared.args.lora_dir`.

These changes:

- Do not alter how adapters are serialized/deserialized beyond enforcing that only files under the configured LoRA directory are used.
- Do not introduce any new dependencies.
- Address the CodeQL warning by ensuring the deserialization target is no longer fully user-controlled, but constrained to a trusted directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
